### PR TITLE
Use Dependabot to check for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Changes:

- Use Dependabot to check for GitHub actions updates

## Context:

This will help you keep your GitHub Actions up-to-date as well.