### PR TITLE
Adds looser date parsing support

### DIFF
--- a/lib/dyck/mobi.rb
+++ b/lib/dyck/mobi.rb
@@ -3,6 +3,7 @@
 require 'dyck/index'
 require 'dyck/palmdb'
 require 'dyck/util'
+require 'stringio'
 require 'time'
 require 'zlib'
 


### PR DESCRIPTION
The "Nightshade Year's Best Horror" mobi files from bundleofholding.com have only a 4-digit year in the date field, which causes an invalid date exception when parsing them. This loosens the date-parsing rules to parse these files. 